### PR TITLE
Update flash-message.scss

### DIFF
--- a/src/flash-message.scss
+++ b/src/flash-message.scss
@@ -15,8 +15,9 @@ $flash-message-prefix: '' !default;
   z-index: 100000;
   top: 0px;
   transition: top 500ms;
+  pointer-events: none;
 
   &.#{$flash-message-prefix}-off-screen {
-    top: -500px;
+    top: -50000px;
   }
 }


### PR DESCRIPTION
pointer events are now set to none, so everything is still clickable,
and the off-screen position is set to the original value of -50000px